### PR TITLE
Fix parseconfig-gemspec so gem build works again

### DIFF
--- a/parseconfig.gemspec
+++ b/parseconfig.gemspec
@@ -11,8 +11,8 @@ Gem::Specification.new do |s|
               "Changelog", 
               "LICENSE", 
               "doc",
-              "demo.rb",
-              "demo.conf",
+              "examples/demo.rb",
+              "examples/demo.conf",
               "lib/parseconfig.rb"]
   
 end


### PR DESCRIPTION
Paths for examples/demo.conf, examples/demo.rb were incorrect in the gemspec, fixed.
