### PR TITLE
removed empty line

### DIFF
--- a/lib/parseconfig.rb
+++ b/lib/parseconfig.rb
@@ -165,7 +165,6 @@ class ParseConfig
         end
       end
     end
-    output_stream.puts "\n"
 
     self.groups.each do |group|
       output_stream.puts "[#{group}]"
@@ -176,7 +175,6 @@ class ParseConfig
           output_stream.puts "#{param} = #{value}"
         end
       end
-      output_stream.puts "\n"
     end
   end
 


### PR DESCRIPTION
- There's an empty line added at the end of each file generated my
  parseconfig. Kinda useless and unclean.
