### PR TITLE
Specify license in gemspec

### DIFF
--- a/parseconfig.gemspec
+++ b/parseconfig.gemspec
@@ -5,6 +5,7 @@ require 'version'
 Gem::Specification.new do |s|
   s.name        = 'parseconfig'
   s.version     = ParseConfig::VERSION
+  s.licenses    = ["MIT"]
   s.date        = '2020-09-28'
   s.authors     = ['BJ Dierkes']
   s.email       = 'derks@datafolklabs.com'


### PR DESCRIPTION
Makes it easy to see what license it uses via the `bundle license` command.